### PR TITLE
Andrew/mac subprocess fix

### DIFF
--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -638,7 +638,9 @@ def diagnose():
     print("")
     sys.stdout.flush()
     sys.stderr.flush()
-    for exception in fail:
-        print(str(exception))
-    if fail: raise BaseException("There was an exception, see above.")
+    if fail:
+        import traceback
+        for exception in fail:
+            traceback.print_exception(exception)
+        raise BaseException("There was an exception, see above.")
     print("Thank you! Please share these results with us!")

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -205,6 +205,7 @@ class Browser(Target):
         self.future_self.set_result(self)
 
     def _clean_temp(self):
+        name = self.temp_dir.name
         clean = False
         try:
             self.temp_dir.cleanup()
@@ -242,7 +243,7 @@ class Browser(Target):
                         f"The temporary directory could not be deleted, execution will continue. {type(e)}: {e}", TempDirWarning
                 )
         if self.debug:
-            print(f"Tempfile still exists?: {bool(os.path.exists(str(self.temp_dir.name)))}")
+            print(f"Tempfile still exists?: {bool(os.path.exists(str(self.name)))}")
 
     async def _is_closed_async(self, wait=0):
         waiter = self.subprocess.wait()

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -242,7 +242,7 @@ class Browser(Target):
                         f"The temporary directory could not be deleted, execution will continue. {type(e)}: {e}", TempDirWarning
                 )
         if self.debug:
-            print(f"Tempfile still exists?: {bool(os.path.isfile(str(self.temp_dir.name)))}")
+            print(f"Tempfile still exists?: {bool(os.path.exists(str(self.temp_dir.name)))}")
 
     async def _is_closed_async(self, wait=0):
         waiter = self.subprocess.wait()

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -583,7 +583,7 @@ def diagnose():
     print(platform.version())
     print(platform.uname())
     print("Looking for browser:".center(50, "*"))
-    print(which_browser())
+    print(which_browser(debug=True))
     try:
         print("Looking for version info:".center(50, "*"))
         import subprocess, sys # noqa

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -607,6 +607,8 @@ def diagnose():
         print(subprocess.check_output(["git", "describe", "--all", "--tags", "--long", "--always",]))
         print(sys.version)
         print(sys.version_info)
+    except BaseException:
+        pass
     finally:
         print("Done with version info.".center(50, "*"))
         pass
@@ -616,6 +618,8 @@ def diagnose():
         browser = Browser(debug=True, debug_browser=True)
         time.sleep(2)
         browser.close()
+    except BaseException:
+        pass
     finally:
         print("Done with sync test".center(50, "*"))
 
@@ -627,6 +631,8 @@ def diagnose():
         print("Running Asyncio Test".center(50, "*"))
         #asyncio.run(test())
         print("Skipped...")
+    except BaseException:
+        pass
     finally:
         print("Asyncio.run done".center(50, "*"))
         pass

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -612,7 +612,7 @@ def diagnose():
         await browser.close()
     try:
         print("Running Asyncio Test".center(50, "*"))
-        #asyncio.run(test())
+        asyncio.run(test())
         print("skip")
     except BaseException as e:
         fail.append(e)

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -83,7 +83,7 @@ class Browser(Target):
         if not path:
             path = default_path
         if path:
-            new_env["BROWSER_PATH"] = path
+            new_env["BROWSER_PATH"] = str(path)
         else:
             raise RuntimeError(
                 "Could not find an acceptable browser. Please set environmental variable BROWSER_PATH or pass `path=/path/to/browser` into the Browser() constructor."

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -610,13 +610,23 @@ def diagnose():
     finally:
         print("Done with version info.".center(50, "*"))
         pass
+    try:
+        print("Sync test".center(50, "*"))
+        import time
+        browser = Browser(debug=True, debug_browser=True)
+        time.sleep(2)
+        browser.close()
+    finally:
+        print("Done with sync test".center(50, "*"))
+
     async def test():
         browser = await Browser(debug=True, debug_browser=True)
         await asyncio.sleep(2)
         await browser.close()
     try:
         print("Running Asyncio Test".center(50, "*"))
-        asyncio.run(test())
+        #asyncio.run(test())
+        print("Skipped...")
     finally:
         print("Asyncio.run done".center(50, "*"))
         pass

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -619,7 +619,7 @@ def diagnose():
         browser = Browser(debug=True, debug_browser=True)
         time.sleep(2)
         browser.close()
-    except BaseException:
+    except BaseException as e:
         fail.append(e)
     finally:
         print("Done with sync test".center(50, "*"))
@@ -631,7 +631,7 @@ def diagnose():
     try:
         print("Running Asyncio Test".center(50, "*"))
         asyncio.run(test())
-    except BaseException:
+    except BaseException as e:
         fail.append(e)
     finally:
         print("Asyncio.run done".center(50, "*"))

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -243,7 +243,7 @@ class Browser(Target):
                         f"The temporary directory could not be deleted, execution will continue. {type(e)}: {e}", TempDirWarning
                 )
         if self.debug:
-            print(f"Tempfile still exists?: {bool(os.path.exists(str(self.name)))}")
+            print(f"Tempfile still exists?: {bool(os.path.exists(str(name)))}")
 
     async def _is_closed_async(self, wait=0):
         waiter = self.subprocess.wait()

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -623,8 +623,10 @@ def diagnose():
         fail.append(e)
     finally:
         print("Done with sync test".center(50, "*"))
-
+    def error_handler(loop, context):
+        print(context)
     async def test():
+        asyncio.get_running_loop().set_exception_handler(error_handler)
         try:
             print("Internal running Asyncio Test".center(50, "*"))
             browser = await Browser(debug=True, debug_browser=True)

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -625,9 +625,15 @@ def diagnose():
         print("Done with sync test".center(50, "*"))
 
     async def test():
-        browser = await Browser(debug=True, debug_browser=True)
-        await asyncio.sleep(2)
-        await browser.close()
+        try:
+            print("Internal running Asyncio Test".center(50, "*"))
+            browser = await Browser(debug=True, debug_browser=True)
+            await asyncio.sleep(2)
+            await browser.close()
+        except BaseException as e:
+            fail.append(e)
+        finally:
+            print("Asyncio.run done internally".center(50, "*"))
     try:
         print("Running Asyncio Test".center(50, "*"))
         asyncio.run(test())
@@ -635,7 +641,6 @@ def diagnose():
         fail.append(e)
     finally:
         print("Asyncio.run done".center(50, "*"))
-        pass
     print("")
     sys.stdout.flush()
     sys.stderr.flush()

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -592,6 +592,7 @@ class Browser(Target):
             return key
 
 def diagnose():
+    fail = []
     print("*".center(50, "*"))
     print("Collecting information about the system:".center(50, "*"))
     print(platform.system())
@@ -607,8 +608,8 @@ def diagnose():
         print(subprocess.check_output(["git", "describe", "--all", "--tags", "--long", "--always",]))
         print(sys.version)
         print(sys.version_info)
-    except BaseException:
-        pass
+    except BaseException as e:
+        fail.append(e)
     finally:
         print("Done with version info.".center(50, "*"))
         pass
@@ -619,7 +620,7 @@ def diagnose():
         time.sleep(2)
         browser.close()
     except BaseException:
-        pass
+        fail.append(e)
     finally:
         print("Done with sync test".center(50, "*"))
 
@@ -629,12 +630,16 @@ def diagnose():
         await browser.close()
     try:
         print("Running Asyncio Test".center(50, "*"))
-        #asyncio.run(test())
-        print("Skipped...")
+        asyncio.run(test())
     except BaseException:
-        pass
+        fail.append(e)
     finally:
         print("Asyncio.run done".center(50, "*"))
         pass
     print("")
+    sys.stdout.flush()
+    sys.stderr.flush()
+    for exception in fail:
+        print(str(exception))
+    if fail: raise BaseException("There was an exception, see above.")
     print("Thank you! Please share these results with us!")

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -613,7 +613,6 @@ def diagnose():
     try:
         print("Running Asyncio Test".center(50, "*"))
         asyncio.run(test())
-        print("skip")
     except BaseException as e:
         fail.append(e)
     finally:
@@ -624,6 +623,7 @@ def diagnose():
     if fail:
         import traceback
         for exception in fail:
-            traceback.print_exception(exception)
+            if exception:
+                traceback.print_exception(exception)
         raise BaseException("There was an exception, see above.")
     print("Thank you! Please share these results with us!")

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -623,22 +623,14 @@ def diagnose():
         fail.append(e)
     finally:
         print("Done with sync test".center(50, "*"))
-    def error_handler(loop, context):
-        print(context)
     async def test():
-        asyncio.get_running_loop().set_exception_handler(error_handler)
-        try:
-            print("Internal running Asyncio Test".center(50, "*"))
-            browser = await Browser(debug=True, debug_browser=True)
-            await asyncio.sleep(2)
-            await browser.close()
-        except BaseException as e:
-            fail.append(e)
-        finally:
-            print("Asyncio.run done internally".center(50, "*"))
+        browser = await Browser(debug=True, debug_browser=True)
+        await asyncio.sleep(2)
+        await browser.close()
     try:
         print("Running Asyncio Test".center(50, "*"))
-        asyncio.run(test())
+        #asyncio.run(test())
+        print("skip")
     except BaseException as e:
         fail.append(e)
     finally:

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -592,27 +592,33 @@ class Browser(Target):
             return key
 
 def diagnose():
-    print("*****************************************")
-    print("Please copy and paste all these results to an issue or to slack!")
-    print("Collecting information about the system:")
+    print("*".center(50, "*"))
+    print("Collecting information about the system:".center(50, "*"))
     print(platform.system())
     print(platform.release())
     print(platform.version())
     print(platform.uname())
-    print("Looking for browser:")
+    print("Looking for browser:".center(50, "*"))
     print(which_browser())
-    print("Running a very simple test...")
     try:
+        print("Looking for version info:".center(50, "*"))
         import subprocess, sys # noqa
         print(subprocess.check_output([sys.executable, '-m', 'pip', 'freeze']))
         print(subprocess.check_output(["git", "describe", "--all", "--tags", "--long", "--always",]))
         print(sys.version)
         print(sys.version_info)
     finally:
+        print("Done with version info.".center(50, "*"))
         pass
     async def test():
         browser = await Browser(debug=True, debug_browser=True)
         await asyncio.sleep(2)
         await browser.close()
-    asyncio.run(test())
+    try:
+        print("Running Asyncio Test".center(50, "*"))
+        asyncio.run(test())
+    finally:
+        print("Asyncio.run done".center(50, "*"))
+        pass
+    print("")
     print("Thank you! Please share these results with us!")

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -182,34 +182,17 @@ class Browser(Target):
         stderr = self._stderr
         env = self._env
         if platform.system() != "Windows":
-            if platform.system() == "Linux":
-                self.subprocess = await asyncio.create_subprocess_exec(
-                    sys.executable,
-                    os.path.join(
-                        os.path.dirname(os.path.realpath(__file__)), "chrome_wrapper.py"
-                    ),
-                    stdin=self.pipe.read_to_chromium,
-                    stdout=self.pipe.write_from_chromium,
-                    stderr=stderr,
-                    close_fds=True,
-                    env=env,
-                )
-            else: # mac doesn't seem to like asyncio.create_subprocess_exec
-                def run():
-                    return subprocess.Popen(
-                        [
-                            sys.executable,
-                            os.path.join(
-                                os.path.dirname(os.path.realpath(__file__)), "chrome_wrapper.py"
-                            ),
-                        ],
-                        close_fds=True,
-                        stdin=self.pipe.read_to_chromium,
-                        stdout=self.pipe.write_from_chromium,
-                        stderr=stderr,
-                        env=env,
-                    )
-                self.subprocess = await asyncio.to_thread(run)
+            self.subprocess = await asyncio.create_subprocess_exec(
+                sys.executable,
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "chrome_wrapper.py"
+                ),
+                stdin=self.pipe.read_to_chromium,
+                stdout=self.pipe.write_from_chromium,
+                stderr=stderr,
+                close_fds=True,
+                env=env,
+            )
         else:
             from .chrome_wrapper import open_browser
             self.subprocess = await open_browser(to_chromium=self.pipe.read_to_chromium,

--- a/devtools/browser.py
+++ b/devtools/browser.py
@@ -182,17 +182,34 @@ class Browser(Target):
         stderr = self._stderr
         env = self._env
         if platform.system() != "Windows":
-            self.subprocess = await asyncio.create_subprocess_exec(
-                sys.executable,
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)), "chrome_wrapper.py"
-                ),
-                stdin=self.pipe.read_to_chromium,
-                stdout=self.pipe.write_from_chromium,
-                stderr=stderr,
-                close_fds=True,
-                env=env,
-            )
+            if platform.system() == "Linux":
+                self.subprocess = await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    os.path.join(
+                        os.path.dirname(os.path.realpath(__file__)), "chrome_wrapper.py"
+                    ),
+                    stdin=self.pipe.read_to_chromium,
+                    stdout=self.pipe.write_from_chromium,
+                    stderr=stderr,
+                    close_fds=True,
+                    env=env,
+                )
+            else: # mac doesn't seem to like asyncio.create_subprocess_exec
+                def run():
+                    return subprocess.Popen(
+                        [
+                            sys.executable,
+                            os.path.join(
+                                os.path.dirname(os.path.realpath(__file__)), "chrome_wrapper.py"
+                            ),
+                        ],
+                        close_fds=True,
+                        stdin=self.pipe.read_to_chromium,
+                        stdout=self.pipe.write_from_chromium,
+                        stderr=stderr,
+                        env=env,
+                    )
+                self.subprocess = await asyncio.to_thread(run)
         else:
             from .chrome_wrapper import open_browser
             self.subprocess = await open_browser(to_chromium=self.pipe.read_to_chromium,

--- a/devtools/pipe.py
+++ b/devtools/pipe.py
@@ -59,6 +59,7 @@ class Pipe:
         except OSError as e:
             raise PipeClosedError() from e
         try:
+            raw_buffer = None # if we fail in read, we already defined
             raw_buffer = os.read(
                 self.read_from_chromium, 10000
             )  # 10MB buffer, nbd, doesn't matter w/ this

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -1,6 +1,7 @@
 import shutil
 import platform
 import os
+import sys
 
 chrome = ["chrome", "Chrome", "google-chrome", "google-chrome-stable", "Chrome.app", "Google Chrome", "chromium", "chromium-browser"]
 chromium = ["chromium", "chromium-browser"]

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -2,7 +2,7 @@ import shutil
 import platform
 import os
 
-chrome = ["chrome", "Chrome", "google-chrome", "google-chrome-stable", "chromium", "chromium-browser"]
+chrome = ["chrome", "Chrome", "google-chrome", "google-chrome-stable", "Chrome.app", "Google Chrome", "chromium", "chromium-browser"]
 chromium = ["chromium", "chromium-browser"]
 # firefox = // this needs to be tested
 # brave = // this needs to be tested
@@ -25,6 +25,7 @@ elif system == "Linux":
 else: # assume mac, or system == "Darwin"
     default_path_chrome = [
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+            "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
             ]
 
 def which_windows_chrome():
@@ -53,24 +54,28 @@ def _is_exe(path):
     finally:
         return res
 
-def which_browser(executable_name=chrome):
+def which_browser(executable_name=chrome, debug=False):
     path = None
     if isinstance(executable_name, str):
         executable_name = [executable_name]
     if platform.system() == "Windows":
         os.environ["NoDefaultCurrentDirectoryInExePath"] = "0"
     for exe in executable_name:
+        if debug: print(f"looking for {exe}", file=sys.stderr)
         if platform.system() == "Windows" and exe == "chrome":
             path = which_windows_chrome()
             if path and _is_exe(path):
                 return path
         path = shutil.which(exe)
+        if debug: print(f"looking for {path}", file=sys.stderr)
         if path and _is_exe(path):
             return path
     default_path = []
     if executable_name == chrome:
         default_path = default_path_chrome
     for candidate in default_path:
+        if debug: print(f"Looking at {candidate}", file=sys.stderr)
         if _is_exe(candidate):
             return default_path
+    if debug: print("Found nothing...")
     return None

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -77,6 +77,6 @@ def which_browser(executable_name=chrome, debug=False):
     for candidate in default_path:
         if debug: print(f"Looking at {candidate}", file=sys.stderr)
         if _is_exe(candidate):
-            return default_path
+            return candidate
     if debug: print("Found nothing...")
     return None

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -25,8 +25,8 @@ elif system == "Linux":
             ]
 else: # assume mac, or system == "Darwin"
     default_path_chrome = [
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-            "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
             ]
 
 def which_windows_chrome():

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -26,7 +26,7 @@ elif system == "Linux":
 else: # assume mac, or system == "Darwin"
     default_path_chrome = [
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
+            r"/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
             ]
 
 def which_windows_chrome():

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -77,5 +77,5 @@ def which_browser(executable_name=chrome, debug=False):
         if debug: print(f"Looking at {candidate}", file=sys.stderr)
         if _is_exe(candidate):
             return candidate
-    if debug: print("Found nothing...")
+    if debug: print("Found nothing...", file=sys.stderr)
     return None

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -3,7 +3,7 @@ import platform
 import os
 import sys
 
-chrome = ["chrome", "Chrome", "google-chrome", "google-chrome-stable", "Chrome.app", "Google Chrome", "chromium", "chromium-browser"]
+chrome = ["chrome", "Chrome", "google-chrome", "google-chrome-stable", "Chrome.app", "Google Chrome", "Google Chrome.app", "chromium", "chromium-browser"]
 chromium = ["chromium", "chromium-browser"]
 # firefox = // this needs to be tested
 # brave = // this needs to be tested

--- a/devtools/system.py
+++ b/devtools/system.py
@@ -26,7 +26,6 @@ elif system == "Linux":
 else: # assume mac, or system == "Darwin"
     default_path_chrome = [
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            r"/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
             ]
 
 def which_windows_chrome():


### PR DESCRIPTION
Mac is throwing some weird errors that linux doesn't throw for

`asyncio.create_subprocess_exe`

Windows doesn't like that one either, fitting in with python's shoddy support of other OSes.

Let's go with a standard `suprocess.Popen` with an `asyncio.to_thread` and see how it goes.

it wasn't that, it was mac not handling a `Path` without `str()` casting which is probably regrestive on their part but is good practice on our part to be explicit anyway 