### PR TITLE
Good housekeeping: Cancel pending futures when browser closed

### DIFF
--- a/choreographer/browser.py
+++ b/choreographer/browser.py
@@ -355,14 +355,14 @@ class Browser(Target):
         if self.loop:
             if not self.future_self.done():
                 self.future_self.set_exception(BrowserFailedError("Close() was called before the browser finished opening- maybe it crashed?"))
-            for future in self.futures:
+            for future in self.futures.values():
                 future.set_exception(BrowserClosedError("Command not completed because browser closed."))
             for session in self.sessions.values():
-                for future in session.subscription_futures.values():
+                for future in session.subscriptions_futures.values():
                     future.set_exception(BrowserClosedError("Event not complete because browser closed."))
-            for tab in self.tabs:
+            for tab in self.tabs.values():
                 for session in tab.sessions.values():
-                    for future in session.subscription_futures.values():
+                    for future in session.subscriptions_futures.values():
                         future.set_exception(BrowserClosedError("Event not completed because browser closed."))
             async def close_task():
                 try:

--- a/choreographer/browser.py
+++ b/choreographer/browser.py
@@ -357,11 +357,11 @@ class Browser(Target):
                 self.future_self.set_exception(BrowserFailedError("Close() was called before the browser finished opening- maybe it crashed?"))
             for future in self.futures:
                 future.set_exception(BrowserClosedError("Command not completed because browser closed."))
-            for session in self.sessions:
+            for session in self.sessions.values():
                 for future in session.subscription_futures.values():
                     future.set_exception(BrowserClosedError("Event not complete because browser closed."))
             for tab in self.tabs:
-                for session in tab.sessions:
+                for session in tab.sessions.values():
                     for future in session.subscription_futures.values():
                         future.set_exception(BrowserClosedError("Event not completed because browser closed."))
             async def close_task():

--- a/choreographer/browser.py
+++ b/choreographer/browser.py
@@ -24,6 +24,8 @@ class TempDirWarning(UserWarning):
     pass
 class UnhandledMessageWarning(UserWarning):
     pass
+class BrowserClosedError(RuntimeError):
+    pass
 
 default_path = which_browser() # probably handle this better
 with_onexc = bool(sys.version_info[:3] >= (3, 12))
@@ -345,6 +347,16 @@ class Browser(Target):
 
     def close(self):
         if self.loop:
+            for future in self.futures:
+                future.set_exception(BrowserClosedError())
+            for session in self.sessions:
+                for future in session.subscription_futures.values():
+                    future.set_exception(BrowserClosedError())
+
+            for tab in self.tabs:
+                for session in tab.sessions:
+                    for future in session.subscription_futures.values():
+                        future.set_exception(BrowserClosedError())
             async def close_task():
                 try:
                     await self._async_close()
@@ -456,35 +468,38 @@ class Browser(Target):
 
     async def populate_targets(self):
         if not self.browser.loop:
-            warnings.warn("This method requires use of an event loop (asyncio).")
-        response = await self.browser.send_command("Target.getTargets")
-        if "error" in response:
-            raise RuntimeError("Could not get targets") from Exception(
-                response["error"]
-            )
+            raise RuntimeError("This method requires use of an event loop (asyncio).")
+        try:
+            response = await self.browser.send_command("Target.getTargets")
+            if "error" in response:
+                raise RuntimeError("Could not get targets") from Exception(
+                    response["error"]
+                )
 
-        for json_response in response["result"]["targetInfos"]:
-            if (
-                json_response["type"] == "page"
-                and json_response["targetId"] not in self.tabs
-            ):
-                target_id = json_response["targetId"]
-                new_tab = Tab(target_id, self)
-                try:
-                    await new_tab.create_session()
-                except DevtoolsProtocolError as e:
-                    if e.code == TARGET_NOT_FOUND:
-                        if self.debug:
-                            print(
-                                f"Target {target_id} not found (could be closed before)",
-                                file=sys.stderr
-                                )
-                        continue
-                    else:
-                        raise e
-                self._add_tab(new_tab)
-                if self.debug:
-                    print(f"The target {target_id} was added", file=sys.stderr)
+            for json_response in response["result"]["targetInfos"]:
+                if (
+                    json_response["type"] == "page"
+                    and json_response["targetId"] not in self.tabs
+                ):
+                    target_id = json_response["targetId"]
+                    new_tab = Tab(target_id, self)
+                    try:
+                        await new_tab.create_session()
+                    except DevtoolsProtocolError as e:
+                        if e.code == TARGET_NOT_FOUND:
+                            if self.debug:
+                                print(
+                                    f"Target {target_id} not found (could be closed before)",
+                                    file=sys.stderr
+                                    )
+                            continue
+                        else:
+                            raise e
+                    self._add_tab(new_tab)
+                    if self.debug:
+                        print(f"The target {target_id} was added", file=sys.stderr)
+        except BrowserClosedError as e:
+            raise RuntimeError("The browser seemed to close immediately after starting. Perhaps addng debug_browser=True will help.") from e
 
     # Output Helper for Debugging
 


### PR DESCRIPTION
This is good housekeeping- explicitly cancel pending features if Chrome crashes.

It will specifically resolve the testing corner-case where chrome does crash on init (especially if trying to run it visually on a linux box with no display)