### PR TITLE
Add flags for enabling gpu and sandbox

### DIFF
--- a/choreographer/browser.py
+++ b/choreographer/browser.py
@@ -56,6 +56,7 @@ class Browser(Target):
         executor=None,
         debug=False,
         debug_browser=None,
+        **kwargs
     ):
         # Configuration
         self.headless = headless
@@ -107,6 +108,10 @@ class Browser(Target):
                 "Could not find an acceptable browser. Please set environmental variable BROWSER_PATH or pass `path=/path/to/browser` into the Browser() constructor."
             )
 
+        if kwargs.get('gpu_enabled', False):
+            new_env["GPU_ENABLED"] = "true"
+        if kwargs.get('sandbox_enabled', False):
+            new_env["SANDBOX_ENABLED"] = "true"
 
         new_env["USER_DATA_DIR"] = str(self.temp_dir.name)
 

--- a/choreographer/browser.py
+++ b/choreographer/browser.py
@@ -59,6 +59,10 @@ class Browser(Target):
         **kwargs
     ):
         # Configuration
+        self.enable_gpu = kwargs.pop("enable_gpu", False)
+        self.enable_sandbox = kwargs.pop("enable_sandbox", False)
+        if len(kwargs):
+            raise ValueError(f"Unknown keyword arguments: {kwargs}")
         self.headless = headless
         self.debug = debug
         self.loop_hack = False # subprocess needs weird stuff w/ SelectorEventLoop
@@ -108,9 +112,9 @@ class Browser(Target):
                 "Could not find an acceptable browser. Please set environmental variable BROWSER_PATH or pass `path=/path/to/browser` into the Browser() constructor."
             )
 
-        if kwargs.get('gpu_enabled', False):
+        if self.enable_gpu:
             new_env["GPU_ENABLED"] = "true"
-        if kwargs.get('sandbox_enabled', False):
+        if self.enable_sandbox:
             new_env["SANDBOX_ENABLED"] = "true"
 
         new_env["USER_DATA_DIR"] = str(self.temp_dir.name)

--- a/choreographer/chrome_wrapper.py
+++ b/choreographer/chrome_wrapper.py
@@ -38,14 +38,16 @@ def open_browser(to_chromium, from_chromium, stderr=None, env=None, loop=None, l
         path,
         "--remote-debugging-pipe",
         "--disable-breakpad",
-        "--no-sandbox",
         "--allow-file-access-from-files",
         "--enable-logging=stderr",
         f"--user-data-dir={user_data_dir}",
         "--no-first-run",
-        "--disable-gpu",
         "--enable-unsafe-swiftshader"
     ]
+    if not env.get("GPU_ENABLED", False):
+        cli.append("--disable-gpu")
+    if not env.get("SANDBOX_ENABLED", False):
+        cli.append("--no-sandbox")
 
     if "HEADLESS" in env:
         cli.append("--headless=old") # temporary fix

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,14 @@ import choreographer as choreo
 # especially in fixtures- since they may buffer your outputs
 # and can freeze w/o dumping the buffer
 
+@pytest.fixture(params=[True, False], ids=["enable_sandbox", ""])
+def sandbox(request):
+    return request.param
+
+@pytest.fixture(params=[True, False], ids=["enable_gpu", ""])
+def gpu(request):
+    return request.param
+
 @pytest.fixture(params=[True, False], ids=["headless", ""])
 def headless(request):
     return request.param

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -10,11 +10,13 @@ from async_timeout import timeout
 import choreographer as choreo
 
 @pytest.mark.asyncio(loop_scope="function")
-async def test_context(capteesys, headless, debug, debug_browser):
+async def test_context(capteesys, headless, debug, debug_browser, sandbox, gpu):
     async with choreo.Browser(
         headless=headless,
         debug=debug,
         debug_browser=debug_browser,
+        enable_sandbox=sandbox,
+        enable_gpu=gpu
     ) as browser, timeout(pytest.default_timeout):
         response = await browser.send_command(command="Target.getTargets")
         assert "result" in response and "targetInfos" in response["result"]
@@ -29,11 +31,13 @@ async def test_context(capteesys, headless, debug, debug_browser):
     await asyncio.sleep(0)
 
 @pytest.mark.asyncio(loop_scope="function")
-async def test_no_context(capteesys, headless, debug, debug_browser):
+async def test_no_context(capteesys, headless, debug, debug_browser, sandbox, gpu):
     browser = await choreo.Browser(
         headless=headless,
         debug=debug,
         debug_browser=debug_browser,
+        enable_sandbox=sandbox,
+        enable_gpu=gpu
     )
     try:
         async with timeout(pytest.default_timeout):


### PR DESCRIPTION
This adds two flags to the browser constructor:

`enable_gpu`

`enable_sandbox`


Solves: https://github.com/plotly/kaleido/issues/173
Mention: https://github.com/plotly/kaleido/issues/211

Will add tests for flags/sudo running