### PR TITLE
Update pipe.py

### DIFF
--- a/choreographer/pipe.py
+++ b/choreographer/pipe.py
@@ -29,6 +29,8 @@ class NumpyEncoder(json.JSONEncoder):
             return float(obj)
         elif hasattr(obj, "dtype") and obj.shape != ():
             return obj.tolist()
+        elif hasattr(obj, "isoformat"):
+            return obj.isoformat()
         return json.JSONEncoder.default(self, obj)
 
 


### PR DESCRIPTION
Support date/datetime object in NumpyEncoder in order to  overcome "datetime.datetime not JSON serializable error when calling write_image method.

By the way, NumpyEncoder can be a more general type encoder instead of only for numpy types, so that it can support types that are not supported in json library by default.