### PR TITLE
Switch json to simplejson

### DIFF
--- a/choreographer/pipe.py
+++ b/choreographer/pipe.py
@@ -29,6 +29,8 @@ class NumpyEncoder(json.JSONEncoder):
             return float(obj)
         elif hasattr(obj, "dtype") and obj.shape != ():
             return obj.tolist()
+        elif hasattr(obj, "isoformat"):
+            return obj.isoformat()
         return json.JSONEncoder.default(self, obj)
 
 

--- a/choreographer/pipe.py
+++ b/choreographer/pipe.py
@@ -11,7 +11,7 @@ class BlockWarning(UserWarning):
 
 # TODO: don't know about this
 # TODO: use has_attr instead of np.integer, you'll be fine
-class NumpyEncoder(simplejson.JSONEncoder):
+class MultiEncoder(simplejson.JSONEncoder):
     """Special json encoder for numpy types"""
 
     def default(self, obj):
@@ -38,7 +38,7 @@ class PipeClosedError(IOError):
     pass
 
 class Pipe:
-    def __init__(self, debug=False, json_encoder=NumpyEncoder):
+    def __init__(self, debug=False, json_encoder=MultiEncoder):
         self.read_from_chromium, self.write_from_chromium = list(os.pipe())
         self.read_to_chromium, self.write_to_chromium = list(os.pipe())
         self.debug = debug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ authors = [
 maintainers = [
   {name = "Andrew Pikul", email = "ajpikul@gmail.com"},
 ]
+dependencies = [
+  "simplejson"
+  ]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Python's standard json encoder doesn't support NaN values (nan, +- inf) json doesn't, `simplejson` does to an extent. (all get converted to null)

This will bring us back to our previous basic support for json, but I'd this route will likely help me fix some fill errors I was seeing in plotly earlier.  Converted all NaN to null doesn't work and breaks fills when using jupyter- but it would be a change for pypi as well.

closes https://github.com/plotly/Kaleido/issues/228