### PR TITLE
Switch simplejson to orjson

### DIFF
--- a/choreographer/pipe.py
+++ b/choreographer/pipe.py
@@ -30,7 +30,7 @@ class Pipe:
         if (
             hasattr(obj, "dtype")
             and hasattr(obj, "shape")
-            and ((obj.dtype.kind == "i") or (obj.dtype.kind == "f"))
+            and hasattr(obj.dtype, "kind")
         ):
             message = orjson.dumps(obj, option=orjson.OPT_SERIALIZE_NUMPY)
         else:

--- a/choreographer/pipe.py
+++ b/choreographer/pipe.py
@@ -29,8 +29,8 @@ class Pipe:
             print("write_json:", file=sys.stderr)
         if (
             hasattr(obj, "dtype")
-            and hasattr(obj, "shape")
-            and hasattr(obj.dtype, "kind")
+            and (hasattr(obj, "shape") and hasattr(obj.dtype, "kind"))
+            or hasattr(obj, "real")
         ):
             message = orjson.dumps(obj, option=orjson.OPT_SERIALIZE_NUMPY)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ maintainers = [
   {name = "Andrew Pikul", email = "ajpikul@gmail.com"},
 ]
 dependencies = [
-  "simplejson"
+  "orjson"
   ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`orjson` simplifies and solves some issues:
-  the datetime issue [https://github.com/ijl/orjson?tab=readme-ov-file#datetime](url)
-  the options about numpy [https://github.com/ijl/orjson?tab=readme-ov-file#numpy](url)
-  use utf-8 "has strict UTF-8 conformance, more correct than the standard library" [https://github.com/ijl/orjson?tab=readme-ov-file#orjson](url)

So, just adding the option `OPT_SERIALIZE_NUMPY` in the `orjson.dumps()`, avoid the issues with numpy and using `orjson` simplifies the code