### PR TITLE
Fix testpypi urls:

### DIFF
--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://pypi.org/p/choreographer
+      url: https://test.pypi.org/p/choreographer
     # Signs this workflow so pypi trusts it
     permissions:
       id-token: write
@@ -80,4 +80,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy
+          repository-url: https://test.pypi.org/legacy/.


### PR DESCRIPTION
I don't remember how or why, but I remember that testpypi needs a . at the end of the URL, and I can't remember where I found that, or why it would be true