### PR TITLE
Reduce logging level for ldd failure

### DIFF
--- a/choreographer/browsers/chromium.py
+++ b/choreographer/browsers/chromium.py
@@ -113,7 +113,9 @@ class Chromium:
         except Exception as e:  # noqa: BLE001
             msg = "ldd failed."
             stderr = p.stderr.decode() if p and p.stderr else None
-            _logger.warning(
+            # Log failure as INFO rather than WARNING so that it's hidden by default,
+            # since browser may succeed even if ldd fails
+            _logger.info(
                 msg  # noqa: G003 + in log
                 + f" e: {e}, stderr: {stderr}",
             )


### PR DESCRIPTION
The default log level for Python is `WARNING`, so any log statements at that level or above will be shown by default.

The `ldd` check is performed before running the browser, so we don't yet know at that point whether or not the browser will run. We want to avoid a confusing situation for the end user where a concerning message about `ldd` failure is displayed in the browser, but the browser runs correctly anyway.