### PR TITLE
Fix: early return condition in `_find_a_chromium_based_browser`

### DIFF
--- a/choreographer/browsers/chromium.py
+++ b/choreographer/browsers/chromium.py
@@ -55,7 +55,8 @@ def _find_a_chromium_based_browser(*, skip_local: bool) -> str | None:
                 if _is_exe(candidate):
                     path = candidate
                     break
-        return path
+        if path:
+            return path
     return None
 
 


### PR DESCRIPTION
If Chrome wasn't found, the function returned None and skipped checking other browsers. This fix ensures all candidates are checked before returning.