### PR TITLE
andrew/fix testing local verify

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install xvfb
         timeout-minutes: 1
       - name: Install choreographer
-        run:  uv sync --no-sources --all-extras
+        run:  uv sync --no-sources --all-extras --locked
       - name: Install google-chrome-for-testing
         run: uv run --no-sources choreo_get_chrome -v
       - name: Diagnose


### PR DESCRIPTION
- **Add diagnostics.**
- **Fix publish to not use sources.**
- **Only allow publish on attempt 1.**
- **Remove uv python pin from GHA, dirties folder.**
- **Add option to enable debug via env var.**
- **Improve debug mode.**
- **Fix: env vars always strings.**
- **Add testing canary to see if we're using testable chrome.**
- **Print sys.path in stderr in canary.**
- **Change pytest import mode to append.**
- **Change pytest import mode to append (FIX).**
- **Adjust poethepoet path alteration.**
- **Update regular tests to enable debug.**
- **Add locked to GHA**
