### PR TITLE
Improve platform architecture detection for arm on Linux and Windows

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+Unreleased
+- Improve platform architecture detection for arm on Linux and Windows [[#290](https://github.com/plotly/choreographer/pull/290)], with thanks to @juliabeliaeva for the contribution!
 v1.3.0
 v1.3.0rc2
 - Check path validity for browser with is_file()

--- a/src/choreographer/cli/_cli_utils.py
+++ b/src/choreographer/cli/_cli_utils.py
@@ -112,8 +112,8 @@ def get_chrome_sync(  # noqa: C901, PLR0912
     if isinstance(path, str):
         path = Path(path)
 
-    arch = arch or get_google_supported_platform_string()
-    if not arch:
+    arch = arch or get_google_platform_string()
+    if arch not in supported_platform_strings:
         raise RuntimeError(
             "You must specify an arch, one of: "
             f"{', '.join(supported_platform_strings)}. "

--- a/src/choreographer/cli/_cli_utils.py
+++ b/src/choreographer/cli/_cli_utils.py
@@ -23,23 +23,29 @@ _chrome_for_testing_url = "https://googlechromelabs.github.io/chrome-for-testing
 supported_platform_strings = ["linux64", "win32", "win64", "mac-x64", "mac-arm64"]
 
 
-def get_google_supported_platform_string() -> str | None:
-    arch_size_detected = "64" if sys.maxsize > 2**32 else "32"
-    arch_detected = "arm" if platform.processor() == "arm" else "x"
+def get_google_platform_string() -> str | None:
+    arch_size_detected = "64" if sys.maxsize > 2 ** 32 else "32"
+    is_x86 = platform.processor() not in {"arm", "aarch64"}
+    arch_detected = "x" if is_x86 else "arm"
 
-    chrome_platform_detected: str | None = None
     if platform.system() == "Windows":
-        chrome_platform_detected = "win" + arch_size_detected
-    elif platform.system() == "Linux":
-        chrome_platform_detected = "linux" + arch_size_detected
-    elif platform.system() == "Darwin":
-        chrome_platform_detected = "mac-" + arch_detected + arch_size_detected
+        if is_x86:
+            return "win" + arch_size_detected
+        return "win-" + arch_detected + arch_size_detected
+    if platform.system() == "Linux":
+        if is_x86:
+            return "linux" + arch_size_detected
+        return "linux-" + arch_detected + arch_size_detected
+    if platform.system() == "Darwin":
+        return "mac-" + arch_detected + arch_size_detected
+    return None
 
-    platform_string = ""
+
+def get_google_supported_platform_string() -> str | None:
+    chrome_platform_detected = get_google_platform_string()
     if chrome_platform_detected in supported_platform_strings:
-        platform_string = chrome_platform_detected
-
-    return platform_string
+        return chrome_platform_detected
+    return ""
 
 
 def get_chrome_download_path(

--- a/src/choreographer/cli/_cli_utils.py
+++ b/src/choreographer/cli/_cli_utils.py
@@ -23,17 +23,21 @@ _chrome_for_testing_url = "https://googlechromelabs.github.io/chrome-for-testing
 supported_platform_strings = ["linux64", "win32", "win64", "mac-x64", "mac-arm64"]
 
 
+# Returns the detected platform string, including ones not in
+# supported_platform_strings (e.g. linux-arm64, win-arm64) so callers
+# can surface them in error messages.
 def get_google_platform_string() -> str | None:
-    arch_size_detected = "64" if sys.maxsize > 2 ** 32 else "32"
-    is_x86 = platform.processor() not in {"arm", "aarch64"}
-    arch_detected = "x" if is_x86 else "arm"
+    arch_size_detected = "64" if sys.maxsize > 2**32 else "32"
+    machine = platform.machine().lower()
+    is_arm = machine in {"arm64", "aarch64"}
+    arch_detected = "arm" if is_arm else "x"
 
     if platform.system() == "Windows":
-        if is_x86:
+        if not is_arm:
             return "win" + arch_size_detected
         return "win-" + arch_detected + arch_size_detected
     if platform.system() == "Linux":
-        if is_x86:
+        if not is_arm:
             return "linux" + arch_size_detected
         return "linux-" + arch_detected + arch_size_detected
     if platform.system() == "Darwin":
@@ -45,7 +49,7 @@ def get_google_supported_platform_string() -> str | None:
     chrome_platform_detected = get_google_platform_string()
     if chrome_platform_detected in supported_platform_strings:
         return chrome_platform_detected
-    return ""
+    return None
 
 
 def get_chrome_download_path(
@@ -100,7 +104,7 @@ class _ZipFilePermissions(zipfile.ZipFile):
         return path
 
 
-def get_chrome_sync(  # noqa: C901, PLR0912
+def get_chrome_sync(  # noqa: C901, PLR0912, PLR0915
     arch: str | None = None,
     i: int | None = None,
     path: str | Path = default_download_path,
@@ -113,11 +117,16 @@ def get_chrome_sync(  # noqa: C901, PLR0912
         path = Path(path)
 
     arch = arch or get_google_platform_string()
+    if arch is None:
+        raise RuntimeError(
+            f"Could not detect a supported platform on {platform.system()!r}. "
+            f"Pass --arch explicitly, one of: "
+            f"{', '.join(supported_platform_strings)}.",
+        )
     if arch not in supported_platform_strings:
         raise RuntimeError(
-            "You must specify an arch, one of: "
-            f"{', '.join(supported_platform_strings)}. "
-            f"Detected {arch} is not supported.",
+            f"Detected platform {arch!r} is not supported by Chrome for Testing. "
+            f"Supported: {', '.join(supported_platform_strings)}.",
         )
 
     if i:


### PR DESCRIPTION
This PR allows better detection of arm processors on Linux and Windows to prevent downloading incorrect binaries and to show a better error message.

Closes #289.